### PR TITLE
new overloaded begin() to allow starting the FTP server using other filesystems than SD.

### DIFF
--- a/examples/ESP32FTPServerExample.cpp
+++ b/examples/ESP32FTPServerExample.cpp
@@ -1,10 +1,11 @@
 #include <WiFi.h>
 #include <WiFiClient.h>
+#include <SD_MMC.h>
 #include "ESP32FtpServer.h"
 
 const char* ssid = "blablabla..."; //WiFi SSID
 const char* password = "blablabla..."; //WiFi Password
-
+ 
 FtpServer ftpSrv;   //set #define FTP_DEBUG in ESP32FtpServer.h to see ftp verbose on serial
 
 void setup(void){
@@ -23,12 +24,31 @@ void setup(void){
   Serial.print("IP address: ");
   Serial.println(WiFi.localIP());
 
-  /////FTP Setup, ensure SD is started before ftp;  /////////
-  
-  if (SD.begin()) {
-      Serial.println("SD opened!");
+  // FTP Setup, ensure SD is started before ftp
+
+  // start SD using the SPI bus
+  SPI.begin(14, 2, 15, 13);    
+  if (SD.begin(13)) {
+      Serial.println("SD opened in SPI mode!");
       ftpSrv.begin("esp32","esp32");    //username, password for ftp.  set ports in ESP32FtpServer.h  (default 21, 50009 for PASV)
-  }    
+  }  
+
+/*
+  // start SD using the SD_MMC mode (1Bit mode)
+  pinMode(2, INPUT_PULLUP); // hardware pullup might be necessary, see https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/sd_pullup_requirements.html
+  if (SD_MMC.begin("/sdcard", true)) {
+      Serial.println("SD opened in MMC mode (1 Bit)!"); 
+      ftpSrv.begin(SD_MMC, "esp32","esp32");    //username, password for ftp.  set ports in ESP32FtpServer.h  (default 21, 50009 for PASV)
+  }  
+*/
+
+ /*
+  // start SD using the SD_MMC mode (4Bit mode)
+  if (SD_MMC.begin()) {
+      Serial.println("SD opened in MMC mode (4 Bit)!"); 
+      ftpSrv.begin(SD_MMC, "esp32","esp32");    //username, password for ftp.  set ports in ESP32FtpServer.h  (default 21, 50009 for PASV)
+  }  
+*/
 }
 
 void loop(void){

--- a/src/ESP32FtpServer.cpp
+++ b/src/ESP32FtpServer.cpp
@@ -664,8 +664,8 @@ boolean FtpServer::processCommand()
     Serial.println(dir);
     #endif
 
-    fs::FS &fs = SD;
-    if (fs.mkdir(dir.c_str()))
+
+    if (_fs->mkdir(dir.c_str()))
     {
       client.println( "257 \"" + String(parameters) + "\" - Directory successfully created");  
     }
@@ -695,8 +695,8 @@ boolean FtpServer::processCommand()
     {
       dir = String(cwdName) +"/" + parameters;
     }
-    fs::FS &fs = SD;
-    if (fs.rmdir(dir.c_str()))
+    
+    if (_fs->rmdir(dir.c_str()))
     {
       client.println( "250 RMD command successful");  
     }

--- a/src/ESP32FtpServer.h
+++ b/src/ESP32FtpServer.h
@@ -37,7 +37,7 @@
 #include <FS.h>
 #include <WiFiClient.h>
 
-#define FTP_SERVER_VERSION "FTP-2020-10-29"
+#define FTP_SERVER_VERSION "FTP-2020-12-12"
 
 #define FTP_CTRL_PORT    21          // Command port on wich server is listening
 #define FTP_DATA_PORT_PASV 50009     // Data port in passive mode
@@ -55,6 +55,7 @@ public:
 
   FtpServer();
   void    begin(String uname, String pword);
+  void    begin(fs::FS &fs, String uname, String pword);
   int     handleFTP();
   uint8_t isConnected();
 
@@ -82,6 +83,8 @@ private:
   WiFiClient data;
 
   File file;
+  fs::FS *_fs;
+  
 
   boolean  dataPassiveConn;
   uint16_t dataPort;


### PR DESCRIPTION
new overloaded begin() method to allow starting the FTP server using other filesystems than SD.

Example for starting the FTP server in SPI or SD-MMC (1-bit, 4-bit) mode.
~double upload speed in 1Bit SD-MMC mode compared to SPI mode
Test shows upload speed 
~350 kB/s (1Bit SD-MMC mode)
~180 kB/s (SPI mode)

begin() is overloaded so no changes to existing code