### PR TITLE
Added Destructor for freeing allocated memory

### DIFF
--- a/src/ESP32FtpServer.cpp
+++ b/src/ESP32FtpServer.cpp
@@ -27,7 +27,8 @@
 //#include <ESP32WebServer.h>
 #include <FS.h>
 //#include "SD.h"
-#include "SD.h"
+#include "SD_MMC.h"
+#define SD SD_MMC
 #include "SPI.h"
 
 #define FTP_DEBUG
@@ -613,6 +614,7 @@ boolean FtpServer::processCommand()
       client.println( "501 No file name");
     else if( makePath( path ))
     {
+      convertToAscii(path);
 		  file = SD.open(path, "w");
       if( !file)
         client.println( "451 Can't open/create " +String(parameters) );
@@ -1004,6 +1006,37 @@ int8_t FtpServer::readChar()
     }
   }
   return rc;
+}
+
+boolean FtpServer::convertToAscii( char * fullName )
+{
+  uint32_t length;
+  uint32_t i;
+  length = strlen(fullName);
+  for(i = 0; i < length; i++){
+    if( fullName[i] > 127 ){
+      if( fullName[i] == 223 ){ // ß
+        fullName[i] = 's';
+      } else if( fullName[i] == 196 ){ // Ä
+        fullName[i] = 'A';
+      } else if( fullName[i] == 228 ){ // ä
+        fullName[i] = 'a';
+      } else if( fullName[i] == 214 ){ // Ö
+        fullName[i] = 'O';
+      } else if( fullName[i] == 246 ){ // ö
+        fullName[i] = 'o';
+      } else if( fullName[i] == 220 ){ // Ü
+        fullName[i] = 'U';
+      } else if( fullName[i] == 252 ){ // ü
+        fullName[i] = 'u';
+      } else {
+        fullName[i] = '?';
+      }
+    }
+  
+  }
+
+  return true;
 }
 
 // Make complete path/name from cwdName and parameters

--- a/src/ESP32FtpServer.cpp
+++ b/src/ESP32FtpServer.cpp
@@ -27,8 +27,7 @@
 //#include <ESP32WebServer.h>
 #include <FS.h>
 //#include "SD.h"
-#include "SD_MMC.h"
-#define SD SD_MMC
+#include "SD.h"
 #include "SPI.h"
 
 #define FTP_DEBUG

--- a/src/ESP32FtpServer.cpp
+++ b/src/ESP32FtpServer.cpp
@@ -42,6 +42,14 @@ FtpServer::FtpServer()
 
 }
 
+FtpServer::~FtpServer()
+{
+  free(buf);
+  free(cmdLine);
+  free(cwdName);
+  free(command);
+}
+
 void FtpServer::begin(String uname, String pword)
 {
   // Tells the ftp server to begin listening for incoming connection

--- a/src/ESP32FtpServer.h
+++ b/src/ESP32FtpServer.h
@@ -57,6 +57,7 @@ public:
   void    begin(String uname, String pword);
   int     handleFTP();
   uint8_t isConnected();
+  ~FtpServer();
 
 private:
   void    iniVariables();

--- a/src/ESP32FtpServer.h
+++ b/src/ESP32FtpServer.h
@@ -70,6 +70,7 @@ private:
   boolean doStore();
   void    closeTransfer();
   void    abortTransfer();
+  boolean convertToAscii( char * fullName );
   boolean makePath( char * fullname );
   boolean makePath( char * fullName, char * param );
   uint8_t getDateTime( uint16_t * pyear, uint8_t * pmonth, uint8_t * pday,

--- a/src/ESP32FtpServer.h
+++ b/src/ESP32FtpServer.h
@@ -90,9 +90,9 @@ private:
   boolean  dataPassiveConn;
   uint16_t dataPort;
   char     *buf;
-  char     *cmdLine;   // where to store incoming char from client
-  char     *cwdName;   // name of current directory
-  char     *command;              // command sent by client
+  char     *cmdLine;                  // where to store incoming char from client
+  char     *cwdName;                  // name of current directory
+  char     *command;                  // command sent by client
   boolean  rnfrCmd;                   // previous command was RNFR
   char     *parameters;               // point to begin of parameters sent by client
   uint16_t iCL;                       // pointer to cmdLine next incoming char


### PR DESCRIPTION
Hi,
just saw that you implemented the feature to turn on/off the Ftp Server in your main project in order to free heap space. However, I'm not sure if that is working like that, as there is no delete of the ftpSrv object. And if so there is no freeing of the allocated memory in the FtpServer Class.
I added a Destructor which is freeing the allocated memory and is invoked when in the main program the delete operation is called.